### PR TITLE
docs(README): add hyperlink to contributor's GitHub profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Transform your content into perfectly formatted eBooks
 <div style="background-color: #1a1a1a; color: #39ff14; padding: 5px; text-align: center; border-radius: 3px;">
    Open Source Project by:
    <ul style="list-style-type: none; padding: 0 0 0 20px; margin: 0; color: #ffffff;">
-      <li>Juan Carlos Quintero Rubiano (<b>JkVely)</b></li>
+      <li>Juan Carlos Quintero Rubiano (<b><a href="https://github.com/JkVely">JkVely</a></b>)</li>
       <li>Contributors are welcome!</li>
    </ul>
 </div>


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change adds a hyperlink to the GitHub profile of Juan Carlos Quintero Rubiano in the project credits section.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R96): Updated the project credits to include a clickable link to Juan Carlos Quintero Rubiano's GitHub profile.