### PR TITLE
Update EPUB model and privacy settings

### DIFF
--- a/e-bmaker/pom.xml
+++ b/e-bmaker/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/jkvely/e-bmaker</url>
 
     <organization>
-        <name>Juan Carlos Quintero Rubiano (JkVely)</name>
+        <name></name>
     </organization>
     
     <licenses>

--- a/e-bmaker/pom.xml
+++ b/e-bmaker/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/jkvely/e-bmaker</url>
 
     <organization>
-        <name></name>
+        <name>E-BMaker</name>
     </organization>
     
     <licenses>
@@ -31,6 +31,7 @@
                 <role>Project Lead</role>
             </roles>
         </developer>
+        <!-- TODO: Add the other Names-->
     </developers>
 
     <properties>

--- a/e-bmaker/src/main/java/io/github/jkvely/model/EpubChapter.java
+++ b/e-bmaker/src/main/java/io/github/jkvely/model/EpubChapter.java
@@ -1,11 +1,11 @@
 package io.github.jkvely.model;
 
-import lombok.Data;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-
 import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * EpubChapter represents a chapter or section in an EPUB book, supporting nested chapters and navigation.
@@ -15,10 +15,9 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class EpubChapter {
-    private String id;
+    private int id;
     private String title;
     private String content;
-    private int order;
     private List<Image> images;
 
     /**

--- a/e-bmaker/src/main/java/io/github/jkvely/model/EpubCover.java
+++ b/e-bmaker/src/main/java/io/github/jkvely/model/EpubCover.java
@@ -1,0 +1,17 @@
+package io.github.jkvely.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * EpubCover represents the cover image and metadata of an EPUB book.
+ */
+@Data
+@AllArgsConstructor
+public class EpubCover {
+    private String title;
+    private List<String> authors;
+    private Image image;
+}

--- a/e-bmaker/src/main/java/io/github/jkvely/model/EpubNotes.java
+++ b/e-bmaker/src/main/java/io/github/jkvely/model/EpubNotes.java
@@ -1,0 +1,17 @@
+package io.github.jkvely.model;
+
+import lombok.Data;
+
+@Data
+public class EpubNotes extends EpubChapter{
+    private int id;
+    private String title;
+    private String footNotes;
+
+    public EpubNotes(int id, String title, String footNotes) {
+        super(id, title, footNotes, null);
+        this.id = id;
+        this.title = title;
+        this.footNotes = footNotes;
+    }
+}


### PR DESCRIPTION
Remove the organization name from the POM file for privacy while adding clarity with a new organization name. Update the `EpubChapter` model to use an integer for the ID and introduce new classes for `EpubCover` and `EpubNotes`, enhancing the EPUB representation.