### PR TITLE
Refactor EpubNotes constructor to remove redundancy

### DIFF
--- a/e-bmaker/src/main/java/io/github/jkvely/model/EpubBook.java
+++ b/e-bmaker/src/main/java/io/github/jkvely/model/EpubBook.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Singular;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 

--- a/e-bmaker/src/main/java/io/github/jkvely/model/EpubNotes.java
+++ b/e-bmaker/src/main/java/io/github/jkvely/model/EpubNotes.java
@@ -4,12 +4,8 @@ import lombok.Data;
 
 @Data
 public class EpubNotes extends EpubChapter{
-    private String title;
-    private String footNotes;
 
     public EpubNotes(int id, String title, String footNotes) {
         super(id, title, footNotes, null);
-        this.title = title;
-        this.footNotes = footNotes;
     }
 }


### PR DESCRIPTION
Eliminate unnecessary fields from the EpubNotes constructor to streamline the code.